### PR TITLE
single course data template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,12 +42,11 @@ node_modules
 yarn-debug.log*
 yarn-error.log*
 .yarn-integrity
+data/course.json
 data/webpack.json
 static/pdfjs
 static/zips
 static/webpack
-data/*
-!data/example_course.json
 ocw-to-hugo.*.log
 *.tgz
 zips

--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,8 @@ data/webpack.json
 static/pdfjs
 static/zips
 static/webpack
-content/courses/*
-!content/courses/_index.md
 data/*
+!data/example_course.json
 ocw-to-hugo.*.log
 *.tgz
 zips

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cp -r $THEME_PATH/dist/* $THEME_PATH/static
 
 ##  course data template
 
-Course level metadata is stored in a `.json` file in the `data/courses` directory with a filename matching the `course_id`.  For example, `1-124j-foundations-of-software-engineering-fall-2000`.
+Course level metadata is stored in a `course.json` file in the `data` directory.
 
 | key | example value | description |
 | --- | --- | --- |

--- a/data/example_course.json
+++ b/data/example_course.json
@@ -1,0 +1,36 @@
+{
+    "course_id": "18-06-linear-algebra-spring-2010",
+    "course_title": "Linear Algebra",
+    "course_image_url": "https://open-learning-course-data-production.s3.amazonaws.com/18-06-linear-algebra-spring-2010/862a5bbedf159572528b0f0766d1e611_18-06s10.jpg",
+    "course_thumbnail_image_url": "https://open-learning-course-data-production.s3.amazonaws.com/18-06-linear-algebra-spring-2010/e041d7e7fe57acfe0bf2d71a6815db0d_18-06s10-th.jpg",
+    "course_image_alternate_text": "A photograph of windows in Philadelphia, representing a block matrix.",
+    "course_image_caption_text": "<p class=\"instruction\">These windows in Philadelphia represent a beautiful block matrix. (Courtesy Gail Corbett. Used with permission.)</p>",
+    "publishdate": "2010-09-10T10:23:13-04:00",
+    "instructors": ["Prof. Gilbert Strang"],
+    "departments": ["Mathematics"],
+    "course_features": [{
+        "feature": "AV special element video",
+        "subfeature": "Tutorial"
+    }, {
+        "feature": "AV lectures",
+        "subfeature": "Video"
+    }, {
+        "feature": "Assignments",
+        "subfeature": "problem sets with solutions"
+    }, {
+        "feature": "Exams",
+        "subfeature": "Solutions"
+    }, {
+        "feature": "Instructor Insights"
+    }],
+    "topics": [{
+        "topic": "Mathematics",
+        "subtopics": [{
+            "subtopic": "Linear Algebra",
+            "specialities": []
+        }]
+    }],
+    "course_numbers": ["18.06"],
+    "term": "Spring 2010",
+    "level": "Undergraduate"
+}

--- a/layouts/course/course_home.html
+++ b/layouts/course/course_home.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ $courseId := .CurrentSection.Params.course_id }}
-{{ $courseData := index .Site.Data.courses $courseId }}
+{{ $courseData := .Site.Data.course }}
 {{ $courseThumbnailUrl := $courseData.course_thumbnail_image_url }}
 {{ $courseImageUrl := $courseData.course_image_url }}
 <!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->

--- a/layouts/partials/course_banner.html
+++ b/layouts/partials/course_banner.html
@@ -3,7 +3,7 @@
 <div id="course-banner" class="p-0">
   <div class="max-content-width m-auto px-5 py-6">
     {{ $courseId := $currentPage.Params.course_id }}
-    {{ $courseData := index .Site.Data.courses $courseId }}
+    {{ $courseData := .Site.Data.course }}
     {{ $menu := index .Site.Menus $courseId }}
     {{ $menuItem := index $menu 0 }}
     <a

--- a/layouts/partials/course_content.html
+++ b/layouts/partials/course_content.html
@@ -1,6 +1,6 @@
 {{ $currentPage := . }}
 {{ $courseId := .Params.course_id }}
-{{ $courseData := index .Site.Data.courses $courseId }}
+{{ $courseData := .Site.Data.course }}
 
 <div class="pb-4 rounded">
   <header>

--- a/layouts/partials/course_features.html
+++ b/layouts/partials/course_features.html
@@ -1,5 +1,5 @@
 {{ $courseId := .context.Params.course_id }}
-{{ $courseData := index .context.Site.Data.courses $courseId }}
+{{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
 <div class="course-features w-100 {{ if $inPanel }}in-panel{{ else }}bg-light{{ end }}">
   <div class="container px-0 mx-0">

--- a/layouts/partials/course_info.html
+++ b/layouts/partials/course_info.html
@@ -1,5 +1,5 @@
 {{ $courseId := .context.Params.course_id }}
-{{ $courseData := index .context.Site.Data.courses $courseId }}
+{{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .args.inPanel }}
 <div class="table-responsive course-info {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander">

--- a/layouts/partials/course_instructor_number.html
+++ b/layouts/partials/course_instructor_number.html
@@ -1,5 +1,5 @@
 {{ $courseId := .Params.course_id }}
-{{ $courseData := index .Site.Data.courses $courseId }}
+{{ $courseData := .Site.Data.course }}
 <div class="instructor-and-number">
   <table class="table table-borderless mb-2">
     <tr>

--- a/layouts/partials/title.html
+++ b/layouts/partials/title.html
@@ -1,6 +1,6 @@
 {{ if isset .Params "course_id" }}
 {{ $courseId := .Params.course_id }}
-{{ $courseData := index .Site.Data.courses $courseId }}
+{{ $courseData := .Site.Data.course }}
 <title>{{- $titleArray := (slice) -}}
 {{- if .Params.Title -}}
   {{- $titleArray = $titleArray | append .Params.Title -}}

--- a/layouts/partials/topics.html
+++ b/layouts/partials/topics.html
@@ -1,5 +1,5 @@
 {{ $courseId := .context.Params.course_id }}
-{{ $courseData := index .context.Site.Data.courses $courseId }}
+{{ $courseData := .context.Site.Data.course }}
 <div class="border-bottom-light mb-2">
   <h4 class="course-info-title font-weight-bold">Topics</h4>
   <ul class="list-unstyled pb-2 m-0">

--- a/layouts/partials/topics_oneline.html
+++ b/layouts/partials/topics_oneline.html
@@ -1,5 +1,5 @@
 {{ $courseId := .context.Params.course_id }}
-{{ $courseData := index .context.Site.Data.courses $courseId }}
+{{ $courseData := .context.Site.Data.course }}
 <ul class="list-unstyled pb-2 m-0">
 {{ range $topic := $courseData.topics }}
   {{ if gt (len $topic.subtopics) 0 }}


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This PR changes the way the theme accesses course metadata by only ever expecting a single `course.json` file in the `data` folder, making course metadata available at `.Site.Data.course`.

#### How should this be manually tested?
 - Clone https://github.com/mitodl/ocw-course-hugo-starter
 - Overwrite `go.mod` with this:
```
module github.com/mitodl/ocw-course-hugo-starter

go 1.13

require github.com/mitodl/ocw-course-hugo-theme v0.0.0-20201223144356-f09e1131729b // indirect
```
 - Run `./build.sh` to build dependencies
 - Obtain data for an OCW course with [ocw-to-hugo](https://github.com/mitodl/ocw-to-hugo)
 - From the `ocw-to-hugo` output, where `COURSE_ID` is the ID of any course (i.e. `18-01-single-variable-calculus-fall-2006`), copy:
   - `content/courses/COURSE_ID/*` -> `ocw-course-hugo-starter/content`
   - `data/courses/COURSE_ID.json` -> `ocw-course-hugo-starter/data/course.json`
 - Run `hugo server` and browse the website at the URL it shows you, make sure the course home page appears correctly

#### Any background context you want to provide?
`ocw-to-hugo` currently outputs course markdown / data templates in a directory structure meant to support `hugo-course-publisher`.  This will be revised in the future.  This project uses the [Hugo Modules](https://gohugo.io/hugo-modules/use-modules/) system.  The `ocw-course-hugo-starter` repo inherits this repo as a Hugo module, and the `go.mod` file denotes the specific commit to pull in.  This means that if you want to test a pull request on the theme, you need to overwrite the `require` line in the `go.mod` file in your starter repo with the most recent commit to the PR, which I have done above.  This is clumsy and I'd like to come up with a better way to test changes in the future.
