### PR TITLE
rework webpack url partial to expect a leading slash

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
       {{ block "main" . }}{{ end }}
     </div>
     {{- $course := .Site.Data.webpack.course -}}
-    {{- $courseJs := printf "/%s" "/" $course.js -}}
+    {{- $courseJs := printf "/%s" $course.js -}}
     <script src="{{ partial "webpack_url.html" $courseJs }}"></script>
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,7 +5,8 @@
     <div class="overflow-auto">
       {{ block "main" . }}{{ end }}
     </div>
-    {{ $course := .Site.Data.webpack.course }}
-    <script src="{{ partial "webpack_url.html" $course.js }}"></script>
+    {{- $course := .Site.Data.webpack.course -}}
+    {{- $courseJs := printf "/%s" "/" $course.js -}}
+    <script src="{{ partial "webpack_url.html" $courseJs }}"></script>
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,6 @@
       {{ block "main" . }}{{ end }}
     </div>
     {{- $course := .Site.Data.webpack.course -}}
-    {{- $courseJs := printf "/%s" $course.js -}}
-    <script src="{{ partial "webpack_url.html" $courseJs }}"></script>
+    <script src="{{ partial "webpack_url.html" $course.js }}"></script>
   </body>
 </html>

--- a/layouts/course/baseof.html
+++ b/layouts/course/baseof.html
@@ -67,10 +67,11 @@
 
   </script>
   {{ partialCached "navigation_js.html" . }}
-  {{ $course := .Site.Data.webpack.course }}
-  {{ $mathjax := .Site.Data.webpack.mathjax }}
+  {{- $course := .Site.Data.webpack.course -}}
+  {{- $courseJs := printf "/%s" "/" $course.js }}
+  {{- $mathjax := .Site.Data.webpack.mathjax -}}
 
-  <script src="{{ partial "webpack_url.html" $course.js }}"></script>
+  <script src="{{ partial "webpack_url.html" $courseJs }}"></script>
   <script src="{{ partial "webpack_url.html" "/mathjax/tex-svg.js" }}" defer></script>
 </body>
 

--- a/layouts/course/baseof.html
+++ b/layouts/course/baseof.html
@@ -68,7 +68,7 @@
   </script>
   {{ partialCached "navigation_js.html" . }}
   {{- $course := .Site.Data.webpack.course -}}
-  {{- $courseJs := printf "/%s" "/" $course.js }}
+  {{- $courseJs := printf "/%s" $course.js }}
   {{- $mathjax := .Site.Data.webpack.mathjax -}}
 
   <script src="{{ partial "webpack_url.html" $courseJs }}"></script>

--- a/layouts/course/baseof.html
+++ b/layouts/course/baseof.html
@@ -68,10 +68,9 @@
   </script>
   {{ partialCached "navigation_js.html" . }}
   {{- $course := .Site.Data.webpack.course -}}
-  {{- $courseJs := printf "/%s" $course.js }}
   {{- $mathjax := .Site.Data.webpack.mathjax -}}
 
-  <script src="{{ partial "webpack_url.html" $courseJs }}"></script>
+  <script src="{{ partial "webpack_url.html" $course.js }}"></script>
   <script src="{{ partial "webpack_url.html" "/mathjax/tex-svg.js" }}" defer></script>
 </body>
 

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,2 +1,2 @@
 {{ $baseUrl := urls.Parse site.BaseURL }}
-{{- printf "//%s/%s" $baseUrl.Host . -}}
+{{- printf "//%s%s" $baseUrl.Host . -}}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,2 +1,2 @@
-{{ $baseUrl := urls.Parse site.BaseURL }}
-{{- printf "//%s%s" $baseUrl.Host . -}}
+{{- $baseUrl := urls.Parse site.BaseURL -}}
+{{- path.Join $baseUrl.Host .  -}}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,2 +1,1 @@
-{{- $baseUrl := urls.Parse site.BaseURL -}}
-{{- printf "%s://%s" $baseUrl.Scheme (path.Join $baseUrl.Host .) -}}
+{{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,2 +1,2 @@
 {{- $baseUrl := urls.Parse site.BaseURL -}}
-{{- path.Join $baseUrl.Host .  -}}
+{{- printf "%s://%s" $baseUrl.Scheme (path.Join $baseUrl.Host .) -}}

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,6 @@ name = "OCW Course"
 license = "MIT"
 licenselink = "https://github.com/yourname/yourtheme/blob/master/LICENSE"
 description = ""
-homepage = "http://example.com/"
 tags = []
 features = []
 min_version = "0.41"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-course-hugo-theme/issues/7

#### What's this PR do?
This PR adjust the way `webpack_url.html` works so it doesn't insert a backslash between the hostname and the path.  Instead, it's up to the code calling the partial to determine if there should be a leading slash or not.

#### How should this be manually tested?
 - Clone https://github.com/mitodl/ocw-to-hugo
 - Use the instructions in the readme to download and convert the included example courses to Hugo markdown, outputting to `private/output`.
 - Clone https://github.com/mitodl/ocw-course-hugo-starter
 - Put the following into `go.mod`:
```
module github.com/mitodl/ocw-course-hugo-starter

go 1.13

require github.com/mitodl/ocw-course-hugo-theme v0.0.0-20210108221043-f64d23de2f96 // indirect

```
 - Run the build with: `./build.sh -o private/output -c ocw-to-hugo/private/output -b http://localhost:3000`

```
<script src="http://localhost:3000/course.79a27.js"></script>
<script src="http://localhost:3000/mathjax/tex-svg.js" defer></script>
```

It should *not* look like this:

```
<script src="http://localhost:3000/course.79a27.js"></script>
<script src="http://localhost:3000//mathjax/tex-svg.js" defer></script>
```
