### PR TITLE
fix ocw-www webpack url

### DIFF
--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,5 +1,5 @@
 {{ $baseUrl := urls.Parse site.BaseURL }}
 {{ if and (isset $baseUrl "Scheme") (isset $baseUrl "Host") }}
-    {{- printf "//%s/%s" $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+    {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
 {{ else }}
     {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -3,3 +3,4 @@
     {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
 {{ else }}
     {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
+{{ end }}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,6 +1,4 @@
 {{- $baseUrl := urls.Parse site.BaseURL -}}
-{{- $scheme := $baseUrl.Scheme -}}
-{{- $host := $baseUrl.Host -}}
 {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
     {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
 {{- else -}}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,1 +1,5 @@
-{{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
+{{ $baseUrl := urls.Parse site.BaseURL }}
+{{ if and (isset $baseUrl "Scheme") (isset $baseUrl "Host") }}
+    {{- printf "//%s/%s" $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+{{ else }}
+    {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,6 +1,8 @@
-{{ $baseUrl := urls.Parse site.BaseURL }}
-{{ if and (isset $baseUrl "Scheme") (isset $baseUrl "Host") }}
-    {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
-{{ else }}
+{{- $baseUrl := urls.Parse site.BaseURL -}}
+{{- $scheme := $baseUrl.Scheme -}}
+{{- $host := $baseUrl.Host -}}
+{{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
     {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
-{{ end }}
+{{- else -}}
+    {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+{{- end -}}


### PR DESCRIPTION
#### What are the relevant tickets?
Follow up to fix an issue caused by merging https://github.com/mitodl/ocw-course-hugo-theme/pull/8/files

#### What's this PR do?
This fixes an issue with recent changes to `webpack_url.html` that cause the RC / prod builds to not generate proper URLs to webpack resources

#### How should this be manually tested?
 - Clone https://github.com/mitodl/ocw-www
 - Spin up `ocw-www` with:
```
yarn install
npm start
```
 - Clone https://github.com/mitodl/ocw-to-hugo
 - Use the instructions in the readme to download and convert the included example courses to Hugo markdown, outputting to `private/output`.
 - Clone https://github.com/mitodl/ocw-course-hugo-starter
 - Put the following into `go.mod`:
```
module github.com/mitodl/ocw-course-hugo-starter

go 1.13

require github.com/mitodl/ocw-course-hugo-theme v0.0.0-20210111154306-9a126340fb2f // indirect

```
 - Run the build with: `./build.sh -o ocw-www/site/public -c ocw-to-hugo/private/output -b http://localhost:3000/courses`
 - Visit a course on your running `ocw-www` site, based on the courses you ran through `ocw-to-hugo`, for example: http://localhost:3000/courses/8-01sc-classical-mechanics-fall-2016/
 - Ensure that all static assets load properly and there are no 404's, and you can also browse into subsections of the course