### PR TITLE
create layout and style specifically for instructor insights

### DIFF
--- a/assets/instructor-insights.js
+++ b/assets/instructor-insights.js
@@ -1,0 +1,1 @@
+import "./scss/instructor-insights.scss"

--- a/assets/scss/instructor-insights.scss
+++ b/assets/scss/instructor-insights.scss
@@ -1,6 +1,7 @@
 @import "variables";
 
 h2 {
+  max-width: 795px;
   color: $black !important;
   border-bottom: 3px solid $border-dark-color;
 }

--- a/assets/scss/instructor-insights.scss
+++ b/assets/scss/instructor-insights.scss
@@ -1,0 +1,6 @@
+@import "variables";
+
+h2 {
+  color: $black !important;
+  border-bottom: 3px solid $border-dark-color;
+}

--- a/assets/webpack/webpack.common.js
+++ b/assets/webpack/webpack.common.js
@@ -7,7 +7,11 @@ const Dotenv = require("dotenv-webpack")
 
 module.exports = {
   entry: {
-    course: ["@babel/polyfill", path.join(__dirname, "..", "index.js")]
+    course: ["@babel/polyfill", path.join(__dirname, "..", "index.js")],
+    instructor_insights: [
+      "@babel/polyfill",
+      path.join(__dirname, "..", "instructor-insights.js")
+    ]
   },
 
   output: {

--- a/assets/webpack/webpack.dev.js
+++ b/assets/webpack/webpack.dev.js
@@ -28,7 +28,8 @@ module.exports = merge(common, {
     },
     historyApiFallback: {
       rewrites: [{ from: /./, to: "404.html" }]
-    }
+    },
+    disableHostCheck: true
   },
 
   plugins: [

--- a/assets/webpack/webpack.dev.js
+++ b/assets/webpack/webpack.dev.js
@@ -16,7 +16,7 @@ module.exports = merge(common, {
   devtool: "eval-source-map",
 
   devServer: {
-    port: process.env.PORT || 3001,
+    port: process.env.PORT || 3002,
     hot: true,
     quiet: false,
     open: false,

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
+  {{ block "extrahead" . }}{{ end }}
   {{ partial "head.html" . }}
   <body>
     <div class="overflow-auto">
       {{ block "main" . }}{{ end }}
     </div>
     {{- $course := .Site.Data.webpack.course -}}
-    <script src="{{ partial "site_root_url.html" $course.js }}"></script>
+    <script src="{{ partial "webpack_url.html" $course.js }}"></script>
   </body>
 </html>

--- a/layouts/course/baseof.html
+++ b/layouts/course/baseof.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
+  {{ block "extrahead" . }}{{ end }}
   {{ partial "head.html" . }}
 <body class="course-home-page">
   <div class="overflow-auto">
@@ -70,8 +71,8 @@
   {{- $course := .Site.Data.webpack.course -}}
   {{- $mathjax := .Site.Data.webpack.mathjax -}}
 
-  <script src="{{ partial "site_root_url.html" $course.js }}"></script>
-  <script src="{{ partial "site_root_url.html" "/mathjax/tex-svg.js" }}" defer></script>
+  <script src="{{ partial "webpack_url.html" $course.js }}"></script>
+  <script src="{{ partial "webpack_url.html" "/mathjax/tex-svg.js" }}" defer></script>
 </body>
 
 </html>

--- a/layouts/course/instructor_insights.html
+++ b/layouts/course/instructor_insights.html
@@ -1,0 +1,7 @@
+{{ define "extrahead" }}
+{{- $instructor_insights := .Site.Data.webpack.instructor_insights -}}
+<link href="{{ partial "webpack_url.html" $instructor_insights.css }}" rel="stylesheet">
+{{ end }}
+{{ define "main" }}
+{{ partial "course_content.html" . }}
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,8 +3,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   {{ partial "title.html" . }}
   {{ $course := .Site.Data.webpack.course }}
-  <link href="{{ partial "site_root_url.html" $course.css }}" rel="stylesheet">
+  <link href="{{ partial "webpack_url.html" $course.css }}" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
+  {{ block "extrahead" . }}{{ end }}
 <style>
 @font-face {
   font-family: 'Material Icons';
@@ -12,9 +13,9 @@
   font-weight: 400;
   src: local('Material Icons'),
     local('MaterialIcons-Regular'),
-    url({{ partial "site_root_url.html" "/fonts/MaterialIcons-Regular.woff2" }}) format('woff2'),
-    url({{ partial "site_root_url.html" "/fonts/MaterialIcons-Regular.woff" }}) format('woff'),
-    url({{ partial "site_root_url.html" "/fonts/MaterialIcons-Regular.ttf" }}) format('truetype');
+    url({{ partial "webpack_url.html" "/fonts/MaterialIcons-Regular.woff2" }}) format('woff2'),
+    url({{ partial "webpack_url.html" "/fonts/MaterialIcons-Regular.woff" }}) format('woff'),
+    url({{ partial "webpack_url.html" "/fonts/MaterialIcons-Regular.ttf" }}) format('truetype');
 }
 </style>
 </head>

--- a/layouts/partials/webpack_url.html
+++ b/layouts/partials/webpack_url.html
@@ -1,0 +1,9 @@
+{{- if site.IsServer -}}
+    {{- if hasPrefix . "/" -}}
+        {{- print "http://localhost:3002" . -}}
+    {{- else -}}
+        {{- print "http://localhost:3002/" . -}}
+    {{- end -}}
+{{- else -}}
+  {{- partial "site_root_url.html" . -}}
+{{- end -}}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack",
     "build:webpack": "cross-env NODE_ENV=production webpack --config assets/webpack/webpack.prod.js",
+    "start:webpack": "webpack-dev-server --config assets/webpack/webpack.dev.js --hot --host 0.0.0.0",
     "lint": "eslint src build-scripts",
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi $PWD/'build-scripts/**/*.js' $PWD/'assets/**/*.js' $PWD/'assets/**/*.scss'",
     "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi $PWD/'build-scripts/**/*.js' $PWD/'assets/**/*.js' $PWD/'assets/**/*.scss'",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prebuild": "rimraf dist",
+    "start": "npm run start:webpack",
     "build": "npm run build:webpack",
     "build:webpack": "cross-env NODE_ENV=production webpack --config assets/webpack/webpack.prod.js",
     "start:webpack": "webpack-dev-server --config assets/webpack/webpack.dev.js --hot --host 0.0.0.0",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR does a couple things:

 - Adds an `npm start` command that starts the webpack dev server on port 3002
 - Adds back `webpack_url.html`, sourcing webpack resources from `http://localhost:3002` if running locally through the dev server, otherwise passing the url to `site_root_url.html`
 - Adds an `extrahead` block to the `baseof.html` templates that can be used to inject additional CSS on any page
 - Adds an `instructor_insights` bundle to the webpack configuration along with a few basic styles from the design to get us started

#### How should this be manually tested?
Prerequisites:
 - Clone this repo as well as `ocw-course-hugo-starter` and `ocw-to-hugo`
 - Generate content for a course with Instructor Insights, for example `6-034-artificial-intelligence-fall-2010`
 - Copy the data template (`6-034-artificial-intelligence-fall-2010.json`) from `ocw-to-hugo`'s output folder to the `data` folder in `ocw-course-hugo-starter` and rename it to `course.json`
 - Edit your `go.mod` file to override the `ocw-course-hugo-theme` module to point to your local copy like so, replacing my path with your local path to the theme repo:
```
module github.com/mitodl/ocw-course-hugo-starter

go 1.13

replace github.com/mitodl/ocw-course-hugo-theme => /home/gumaerc/Code/ocw-course-hugo-theme

require github.com/mitodl/ocw-course-hugo-theme v1.0.1 // indirect

```
 - Start the Hugo server in `ocw-course-hugo-starter`, again replacing my path to the content created by `ocw-to-hugo` with your local path:
 ```
 hugo server --contentDir ~/Code/ocw-to-hugo/private/output/content/courses/6-034-artificial-intelligence-fall-2010/
 ```

Testing this PR:
 - With this branch of `ocw-course-hugo-theme checked out, run `yarn install && npm start`
 - Browse to the course at the URL Hugo reports for your dev server (most likely http://localhost:1313) and verify that the site loads.
 - Navigate to the Instructor Insights page and verify that you see the following in the page source: `<link href="http://localhost:3002/instructor_insights.css" rel="stylesheet">`
 - Verify that you do *not* see the above CSS file linked in other course pages that are *not* Instructor Insights or its children
 - Look over the style.  More changes will come in a later PR, the main ones to look at here are the underline below sub-section titles and the color change to black from red.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/105410540-1232b300-5c00-11eb-8d2f-50a06ca7448a.png)
![image](https://user-images.githubusercontent.com/12089658/105410645-3f7f6100-5c00-11eb-80f1-f230c06a3d98.png)

