### PR TITLE
Add aria-expanded to links which expand or collapse content

### DIFF
--- a/assets/js/course_expander.js
+++ b/assets/js/course_expander.js
@@ -3,10 +3,12 @@ const toggleExpand = (button, container) => {
   const text = button.querySelector(".text")
   if (expanded) {
     button.classList.remove("expanded")
+    button.setAttribute("aria-expanded", "false")
     container.classList.add("collapsed")
     button.querySelector(".material-icons").textContent = "keyboard_arrow_right"
   } else {
     button.classList.add("expanded")
+    button.setAttribute("aria-expanded", "true")
     container.classList.remove("collapsed")
     button.querySelector(".material-icons").textContent = "keyboard_arrow_down"
   }

--- a/layouts/course/course_home.html
+++ b/layouts/course/course_home.html
@@ -29,7 +29,7 @@
         <div class="mb-3 description">{{- .Content -}}</div>
         <div class="mb-3">
           {{ if $shouldCollapseContent }}
-            <button class="expand-link">
+            <button class="expand-link" aria-expanded="false">
               <span class="text">Read More</span> <i class="material-icons">keyboard_arrow_right</i>
             </button>
           {{ end }}

--- a/layouts/partials/course_info.html
+++ b/layouts/partials/course_info.html
@@ -4,7 +4,7 @@
 <div class="table-responsive course-info {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander">
     {{ if not $inPanel }}
-    <a class="expand-link d-flex align-items-center text-decoration-none" href="#">
+    <a class="expand-link d-flex align-items-center text-decoration-none" aria-expanded="false" href="#">
       <h4 class="course-info-title font-weight-bold d-inline m-0">Course Info</h4>
       <span class="material-icons">keyboard_arrow_right</span>
     </a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #19 

#### What's this PR do?
Sets `aria-expanded="false"` for the collapse/expand links on the course page, and adds JS to toggle the value.

#### How should this be manually tested?
I'm new to this so let me know if things are not working correctly. But in general:

 - Checkout this branch of this project and the main branch of [ocw-course-hugo-starter](https://github.com/mitodl/ocw-course-hugo-starter/)
 - In `ocw-course-hugo-starter`, modify `go.mod` to look similar to this, adding the `replace` line and substituting the location for your locally checked out `ocw-course-hugo-theme` directory:

        module github.com/mitodl/ocw-course-hugo-starter
        
        go 1.13
        
        replace github.com/mitodl/ocw-course-hugo-theme => /home/george/Projects/ocw-course-hugo-theme
        
        require github.com/mitodl/ocw-course-hugo-theme v1.1.0 // indirect

 - If you haven't already, run `ocw-to-hugo` to generate markdown and JSON for use with hugo.
 - Copy `ocw-to-hugo/private/output/content/data/courses/6-034-artificial-intelligence-fall-2010.json` to `ocw-course-hugo-starter/data/course.json`.
 - Run `hugo mod get -u` and `hugo mod vendor`
 - Then run a command like `hugo server --contentDir ~/Projects/ocw-to-hugo/private/output/content/courses/6-034-artificial-intelligence-fall-2010`, substituting a course directory which contains the output from `ocw-to-hugo`. Most courses should have enough text in the description to show the "Read more" link, but some won't. The `6-034-artificial-intelligence-fall-2010` course should have everything you need to test.
 - Leave that server running. Go to the `ocw-course-hugo-theme` directory and run `npm start`.
 - Go to `http://localhost:1313` and inspect the "Read more" link underneath the course description with your browser. You should see a `aria-expanded="false"` attribute. Click the button and it will say "Show less". Inspect the button and it should say `aria-expanded="true"`.
 - You should be able to click the "Course info" title and expand and collapse that, and see similar changes to `aria-expanded` there.