### PR TITLE
add parent title to pages that have it set

### DIFF
--- a/assets/scss/course.scss
+++ b/assets/scss/course.scss
@@ -297,7 +297,7 @@ article.content {
   border-bottom: 1px solid $border-dark-color;
 }
 
-.course-section-title-container .parentTitle {
+.course-section-title-container .parent-title {
   font-size: 1.5rem;
   text-transform: uppercase;
 }

--- a/assets/scss/course.scss
+++ b/assets/scss/course.scss
@@ -296,3 +296,8 @@ article.content {
   max-width: 795px;
   border-bottom: 1px solid $border-dark-color;
 }
+
+.course-section-title-container .parentTitle {
+  font-size: 1.5rem;
+  text-transform: uppercase;
+}

--- a/assets/scss/instructor-insights.scss
+++ b/assets/scss/instructor-insights.scss
@@ -3,7 +3,11 @@
 h2 {
   max-width: 795px;
   color: $black !important;
-  border-bottom: 3px solid $border-dark-color;
+  margin-bottom: 1.25rem !important;
+}
+
+p {
+  margin-bottom: 1.25rem;
 }
 
 .quotewrapper {

--- a/layouts/partials/course_content.html
+++ b/layouts/partials/course_content.html
@@ -1,7 +1,7 @@
 <div class="pb-4 rounded">
   <header>
     <div class="course-section-title-container">
-      {{ with .Params.parentTitle }}
+      {{ with .Params.parent_title }}
       <h3 class="parent-title">{{ . }}</h3>
       {{ end }}
       <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>

--- a/layouts/partials/course_content.html
+++ b/layouts/partials/course_content.html
@@ -1,18 +1,14 @@
-{{ $currentPage := . }}
-{{ $courseId := .Params.course_id }}
-{{ $courseData := .Site.Data.course }}
-
 <div class="pb-4 rounded">
   <header>
     <div class="course-section-title-container">
-      <h1 class="text-uppercase font-weight-bold">{{ $currentPage.Title }}</h1>
-      {{ with $courseData.subtitle }}
-      <span class="subtitle">{{ . }}</span>
+      {{ with .Params.parentTitle }}
+      <h3 class="parent-title">{{ . }}</h3>
       {{ end }}
+      <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
     </div>
   </header>
   {{ partial "mobile_nav_toggle.html" . }}
-  <article class="content pt-2">
-    <main>{{- $currentPage.Content -}}</main>
+  <article class="content pt-3 mt-1">
+    <main>{{- .Content -}}</main>
   </article>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR looks for the `parent_title` front matter property, and if it exists the title is displayed above the section title.

#### How should this be manually tested?
 - Clone `ocw-to-hugo` on the `cg/parent-title` branch and generate content for `6-034-artificial-intelligence-fall-2010`
 - Clone `ocw-course-hugo-starter` and copy the contents of `6-034-artificial-intelligence-fall-2010.json` from the `ocw-to-hugo` output into `data/course.json` 
 - Replace `ocw-course-hugo-starter`'s `go.mod` contents with the following, replacing my path to `ocw-course-hugo-theme` with yours:
```
module github.com/mitodl/ocw-course-hugo-starter

go 1.13

replace github.com/mitodl/ocw-course-hugo-theme => /home/gumaerc/Code/ocw-course-hugo-theme

require github.com/mitodl/ocw-course-hugo-theme v1.2.0 // indirect

```
 - Run `hugo server --contentDir ~/Code/ocw-to-hugo/private/output/content/courses/6-034-artificial-intelligence-fall-2010/`, replacing  my path to `ocw-to-hugo` with yours
 - Browse to http://localhost:1313/sections/instructor-insights/teaching-heuristics/ and ensure that "Instructor Insights" appears above the section title as in the designs: https://projects.invisionapp.com/d/main#/console/18609637/442724922/preview

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/105911812-93bb8400-5ff8-11eb-8aae-5be914f298b2.png)
![image](https://user-images.githubusercontent.com/12089658/105911897-a9c94480-5ff8-11eb-8cd6-aab5cfaec89f.png)

