### PR TITLE
Add baseurl shortcode

### DIFF
--- a/layouts/shortcodes/baseurl.html
+++ b/layouts/shortcodes/baseurl.html
@@ -1,0 +1,1 @@
+{{ .Site.BaseURL }}

--- a/layouts/shortcodes/baseurl.html
+++ b/layouts/shortcodes/baseurl.html
@@ -1,1 +1,1 @@
-{{ .Site.BaseURL }}
+{{- strings.TrimSuffix "/" site.BaseURL -}}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-to-hugo/pull/175

#### What's this PR do?
Adds a `baseurl` shortcode which will be produced in ocw-to-hugo output

#### How should this be manually tested?
I don't think there's an easy way to do this at the moment. If your docker setup is set up to point to a local course you could add `{{< baseurl >}}` somewhere and see if you get the expected string in the output.
