### PR TITLE
fix course home link

### DIFF
--- a/layouts/partials/course_banner.html
+++ b/layouts/partials/course_banner.html
@@ -4,11 +4,10 @@
   <div class="max-content-width m-auto px-5 py-6">
     {{ $courseId := $currentPage.Params.course_id }}
     {{ $courseData := .Site.Data.course }}
-    {{ $menu := index .Site.Menus $courseId }}
-    {{ $menuItem := index $menu 0 }}
+    {{ $courseHomePage := .Site.GetPage "/" }}
     <a
       class="{{ $bannerClass }}"
-      href="{{ $menuItem.URL }}"
+      href="{{ $courseHomePage.URL }}"
     >{{ $courseData.course_title }}</a>
   </div>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/162

#### What's this PR do?
This PR fixes the link to the course home page that is supposed to be on the course title banner.  It had previously been getting the URL of the course home menu item, but since the course home page is not in the left nav anymore we have to do it a different way.  I used `.Site.GetPage "/"`

#### How should this be manually tested?
Spin up any course, navigate to a subsection and then ensure clicking the course title in the banner brings you to the course home page.

