### PR TITLE
add approx-students shortcode

### DIFF
--- a/assets/scss/instructor-insights.scss
+++ b/assets/scss/instructor-insights.scss
@@ -36,3 +36,23 @@ figcaption {
   order: 2;
   font-size: 1.25em;
 }
+
+.approx-students {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: $approx-students-red;
+  border-radius: 50%;
+  h1 {
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+  }
+
+  h1,
+  h2 {
+    color: $white !important;
+    text-transform: none !important;
+    user-select: none;
+  }
+}

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -25,6 +25,7 @@ $course-blue: #126f9a;
 
 // full-color design
 $highlight-red: #a31f34;
+$approx-students-red: #a22732;
 $orange: #ff8a1f;
 $link-blue: #126f9a;
 $text-gray: #7c7b7d;

--- a/layouts/shortcodes/approx-students.html
+++ b/layouts/shortcodes/approx-students.html
@@ -1,0 +1,7 @@
+{{ $numStudents := .Get 0 }}
+{{/* Calculate the diameter based on the amount of digits */}}
+{{ $diameter := add 110 (mul (sub (len (string $numStudents)) 3) 16) }}
+<div class="approx-students" style="width: {{ $diameter }}px; height: {{ $diameter }}px;">
+  <h1>~{{ $numStudents }}</h1>
+  <h2>students</h2>
+</div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR adds the `approx-students.html` shortcode, which takes a single argument of a number of approximate students to render in a red circle with white text as shown in the screenshots.

#### How should this be manually tested?
Read the readme to learn how to test course sites locally using Docker if you are unfamiliar with the process.
 - Make sure `OCW_TO_HUGO_PATH` is set in your env to a locally cloned copy of `ocw-to-hugo` and check out the `cg/approx-students` branch.
 - Spin up a test site for `6-034-artificial-intelligence-fall-2010` and browse to the Instructor Insights page.  You should see the red circle with "~300 students" in it and if you inspect it it should be rendered with HTML, not as a static image.  Test this in whatever browsers you have access to.
 - Spin up another test site for `res-10-001-making-science-and-engineering-pictures-a-practical-guide-to-presenting-your-work-spring-2016` and go to the Instructor insights page.  Verify that the same red circle is there, except it is a little bit larger to accommodate the text "~12000 students."

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/109224585-28490b80-778a-11eb-8be4-18e3476a3c0a.png)
![image](https://user-images.githubusercontent.com/12089658/109224678-49116100-778a-11eb-8fdc-d43f1131bbbd.png)
![image](https://user-images.githubusercontent.com/12089658/109224882-8aa20c00-778a-11eb-844e-0b516218fa12.png)
![image](https://user-images.githubusercontent.com/12089658/109224943-a2799000-778a-11eb-92d0-51ab6596589f.png)

