### PR TITLE
add search icon to header with link to /search

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -45,6 +45,16 @@ $desktop-header-height: 70px;
     .right {
       justify-content: flex-end;
 
+      .search-icon {
+        display: flex;
+        text-decoration: none;
+        color: $orange;
+
+        .material-icons {
+          font-size: 1.75rem;
+        }
+      }
+
       .orange-link {
         background-color: $orange;
         font-size: 16px;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,6 +22,9 @@
       </div>
     </div>
     <div class="right">
+      <a class="search-icon pr-6" href="/search">
+        <i class="material-icons">search</i>
+      </a>
       <a class="btn orange-link py-2 px-3" href="https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home">
         <div class="text-white font-weight-bold w-100">Give now</div>
       </a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-course-hugo-theme/issues/15

#### What's this PR do?
This PR adds a search icon to the header that is hardcoded to `/search`

#### How should this be manually tested?
Spin up any course site locally with docker.  Ensure that the search icon appears and that it links to http://localhost:1313/search.  No page will load there when running a site locally in docker, but this should indicate that the link is correct.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/109871557-4fe01e00-7c39-11eb-9ef0-d5e76de1e3ad.png)

