### PR TITLE
remove coming soon class

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -35,7 +35,7 @@
         <div class="text-white font-weight-bold w-100 px-3 py-2 coming-soon">help & faqs</div>
       </a>
       <a href="https://ocw.mit.edu/about/contactus/">
-        <div class="text-white font-weight-bold w-100 px-3 py-2 coming-soon">contact us</div>
+        <div class="text-white font-weight-bold w-100 px-3 py-2">contact us</div>
       </a>
     </div>
   </div>


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes the coming soon class from the contact us link

#### How should this be manually tested?
Run the site, click "Contact Us" and ensure that you don't see a "Coming Soon" popup.
