### PR TITLE
update docker config for new ocw-to-hugo output structure

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -15,10 +15,9 @@ else
   echo "{\"courses\":[\"${OCW_TEST_COURSE}\"]}" | tee /ocw-data/courses.json
   cd /ocw-to-hugo && node . -i ${OCW_TO_HUGO_INPUT:-/ocw-data/input} \
     -o /ocw-data/output -c /ocw-data/courses.json --download ${OCW_TO_HUGO_DOWNLOAD:-true}
-  rm -rf /ocw-to-hugo-output/* && mkdir /ocw-to-hugo-output/content && mkdir /ocw-to-hugo-output/data
+  rm -rf /ocw-to-hugo-output/*
   cp /theme/docker/hugo/go.mod /ocw-to-hugo-output/go.mod
   cp /theme/docker/hugo/config.toml /ocw-to-hugo-output/config.toml
-  cp -R /ocw-data/output/content/courses/${OCW_TEST_COURSE}/* /ocw-to-hugo-output/content/
-  cp /ocw-data/output/data/courses/${OCW_TEST_COURSE}.json /ocw-to-hugo-output/data/course.json
+  cp -R /ocw-data/output/${OCW_TEST_COURSE}/* /ocw-to-hugo-output/
   cd /ocw-to-hugo-output && /usr/local/bin/hugo server --bind 0.0.0.0
 fi


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/214

#### What's this PR do?
This PR updates the docker start script to match the new `ocw-to-hugo` output structure that's changed by [this](https://github.com/mitodl/ocw-to-hugo/pull/216) PR.

#### How should this be manually tested?
 - Make sure you have `ocw-to-hugo` cloned locally and check out the `cg/single-course-output-structure` branch
 - Set up this project to use `ocw-to-hugo` to download and convert a course based on the docker instructions in the readme
 - Run `cd docker && docker-compose up` and ensure that the course site is locally available at http://localhost:1313
