### PR TITLE
vertical align table cell content

### DIFF
--- a/assets/scss/course-nav.scss
+++ b/assets/scss/course-nav.scss
@@ -12,7 +12,7 @@
 
 .desktop-nav {
   @include media-breakpoint-up(xl) {
-    max-width: 470px;
+    max-width: $desktop-nav-max-width;
   }
 }
 

--- a/assets/scss/course.scss
+++ b/assets/scss/course.scss
@@ -11,6 +11,7 @@
 @import "course-home";
 @import "drawer";
 @import "pdf";
+@import "tables";
 @import "video";
 
 a.coming-soon {

--- a/assets/scss/tables.scss
+++ b/assets/scss/tables.scss
@@ -1,0 +1,19 @@
+.table {
+  thead th,
+  td {
+    vertical-align: middle !important;
+  }
+
+  .fullwidth-cell {
+    position: relative;
+    display: inline;
+  }
+
+  .fullwidth-cell-inner {
+    position: absolute;
+    width: calc(
+      (#{$max-content-width} - #{$desktop-nav-max-width}) * 0.6666667
+    );
+    margin: auto;
+  }
+}

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -1,4 +1,5 @@
 $max-content-width: 1447px;
+$desktop-nav-max-width: 470px;
 $enable-responsive-font-sizes: true;
 $font-size-base: 0.8rem;
 $headings-font-weight: 600;

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -15,10 +15,9 @@ else
   echo "{\"courses\":[\"${OCW_TEST_COURSE}\"]}" | tee /ocw-data/courses.json
   cd /ocw-to-hugo && node . -i ${OCW_TO_HUGO_INPUT:-/ocw-data/input} \
     -o /ocw-data/output -c /ocw-data/courses.json --download ${OCW_TO_HUGO_DOWNLOAD:-true}
-  rm -rf /ocw-to-hugo-output/* && mkdir /ocw-to-hugo-output/content && mkdir /ocw-to-hugo-output/data
+  rm -rf /ocw-to-hugo-output/*
   cp /theme/docker/hugo/go.mod /ocw-to-hugo-output/go.mod
   cp /theme/docker/hugo/config.toml /ocw-to-hugo-output/config.toml
-  cp -R /ocw-data/output/content/courses/${OCW_TEST_COURSE}/* /ocw-to-hugo-output/content/
-  cp /ocw-data/output/data/courses/${OCW_TEST_COURSE}.json /ocw-to-hugo-output/data/course.json
+  cp -R /ocw-data/output/${OCW_TEST_COURSE}/* /ocw-to-hugo-output/
   cd /ocw-to-hugo-output && /usr/local/bin/hugo server --bind 0.0.0.0
 fi

--- a/layouts/shortcodes/fullwidth-cell.html
+++ b/layouts/shortcodes/fullwidth-cell.html
@@ -1,1 +1,3 @@
-<div class="position-absolute">{{ .Inner | markdownify }}</div>
+<div class="fullwidth-cell">
+  <div class="fullwidth-cell-inner">{{ .Inner | markdownify }}</div>&nbsp;
+</div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-course-hugo-theme/issues/47

#### What's this PR do?
This PR vertically centers the contents of table cells.  The `fullwidth-cell` shortcode was also tweaked so that OCW inline "header" cells still look right.

#### How should this be manually tested?
Spin up a course site with a table in it, like `15-s12-blockchain-and-money-fall-2018`.  view the table and ensure that the contents of cells are centered.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/110714865-2fccd380-81d2-11eb-82f8-24d920e99863.png)
![image](https://user-images.githubusercontent.com/12089658/110714832-20e62100-81d2-11eb-8415-9bbf6cc6b8ad.png)

