### PR TITLE
video gallery item baseurl

### DIFF
--- a/layouts/shortcodes/video-gallery-item.html
+++ b/layouts/shortcodes/video-gallery-item.html
@@ -2,7 +2,7 @@
     {{- with .Site.GetPage (.Get "href") }}
 		<a class="video-link" href="{{- .URL -}}">
     {{ else }}
-    <a class="video-link" href="{{- .Site.BaseURL -}}{{- .Get "href" -}}">
+    <a class="video-link" href="{{- partial "site_root_url.html" (.Get "href") -}}">
 		{{ end }}
       <div class="inner-container">
         <div class="left-col">

--- a/layouts/shortcodes/video-gallery-item.html
+++ b/layouts/shortcodes/video-gallery-item.html
@@ -2,7 +2,7 @@
     {{- with .Site.GetPage (.Get "href") }}
 		<a class="video-link" href="{{- .URL -}}">
     {{ else }}
-    <a class="video-link" href="{{- .Get "href" -}}">
+    <a class="video-link" href="{{- .Site.BaseURL -}}{{- .Get "href" -}}">
 		{{ end }}
       <div class="inner-container">
         <div class="left-col">

--- a/layouts/shortcodes/video-gallery-item.html
+++ b/layouts/shortcodes/video-gallery-item.html
@@ -1,23 +1,24 @@
-  <div class="mb-2 border-light-gray rounded video-gallery-card">
-    {{- with .Site.GetPage (.Get "href") }}
-		<a class="video-link" href="{{- .URL -}}">
-    {{ else }}
-    <a class="video-link" href="{{- partial "site_root_url.html" (.Get "href") -}}">
-		{{ end }}
-      <div class="inner-container">
-        <div class="left-col">
-              <img class="thumbnail" src ="{{ .Get "thumbnail" }}" />
-              <img class="youtube-logo-overlay" src="/images/youtube.svg" />
-        </div>
-        <div class="right-col">
-          <h5 class="section-title">{{ .Get "section" }}</h5>
-          <h5 class="video-title">{{ .Get "title" }}</h5>
-          <div class="video-description">{{ .Get "description" }}</div>
-          <div class="play-button">
-            <span>PLAY</span>
-            <i class="material-icons">play_arrow_icon</i>
-          </div>
+{{- $href := .Get "href" -}}
+<div class="mb-2 border-light-gray rounded video-gallery-card">
+  {{- with .Site.GetPage $href }}
+  <a class="video-link" href="{{- .URL -}}">
+  {{ else }}
+  <a class="video-link" href="{{- strings.TrimSuffix "/" .Site.BaseURL -}}/{{- strings.TrimPrefix "/" $href -}}">
+  {{ end }}
+    <div class="inner-container">
+      <div class="left-col">
+            <img class="thumbnail" src ="{{ .Get "thumbnail" }}" />
+            <img class="youtube-logo-overlay" src="/images/youtube.svg" />
+      </div>
+      <div class="right-col">
+        <h5 class="section-title">{{ .Get "section" }}</h5>
+        <h5 class="video-title">{{ .Get "title" }}</h5>
+        <div class="video-description">{{ .Get "description" }}</div>
+        <div class="play-button">
+          <span>PLAY</span>
+          <i class="material-icons">play_arrow_icon</i>
         </div>
       </div>
-    </a>
-  </div>
+    </div>
+  </a>
+</div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/223

#### What's this PR do?
The `href` argument passed into the `video-gallery-item` shortcode uses `.Site.GetPage` to get the page object the video is referring to and the link is rendered using the .URL property.  In the case `.Site.GetPage` fails, the `href` property is written as passed in.  This PR prepends `.Site.BaseURL` to that, so the URL respects the Hugo site's `baseURL` property.

#### How should this be manually tested?
 - Clone `ocw-studio` and make sure you have it up and running locally
 - Clone `ocw-www`, point it at your instance of `ocw-studio` and start it up
 - Clone `ocw-to-hugo` place the following in `private/courses.json`:
 ```json
{
  "courses": ["6-0002-introduction-to-computational-thinking-and-data-science-fall-2016"]
}
 ```
 - Generate content for this course by running `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Clone `ocw-course-hugo-theme` and check out `cg/video-gallery-item-baseurl`
 - Clone `ocw-course-hugo-starter` and modify the `go.mod` file to point at your local copy of `ocw-course-hugo-theme`, changing the path to match where you have your copy stored:
```
module github.com/mitodl/ocw-course-hugo-starter

go 1.13

replace github.com/mitodl/ocw-course-hugo-theme => /home/gumaerc/Code/ocw-course-hugo-theme

require github.com/mitodl/ocw-course-hugo-theme v1.8.0 // indirect
```
 - Run the following command in `ocw-course-hugo-starter`, replacing the paths to `ocw-www` and `ocw-course-hugo-starter` with the paths to your local copies:
```
./build.sh -o ~/Code/ocw-www/site/public -c ~/Code/ocw-to-hugo/private/output -b http://localhost:3000/courses -v
```
 - Browse to http://localhost:3000/courses/6-0002-introduction-to-computational-thinking-and-data-science-fall-2016/sections/lecture-videos/ and ensure that when you click on the video gallery item for lecture 10 that it loads the video page properly.  The link to the video should be http://localhost:3000/courses/6-0002-introduction-to-computational-thinking-and-data-science-fall-2016/sections/lecture-videos/lecture-10-understanding-experimental-data-cont./
