### PR TITLE
remove extra topics

### DIFF
--- a/layouts/partials/course_info.html
+++ b/layouts/partials/course_info.html
@@ -1,6 +1,6 @@
 {{ $courseId := .context.Params.course_id }}
 {{ $courseData := .context.Site.Data.course }}
-{{ $inPanel := .args.inPanel }}
+{{ $inPanel := .inPanel }}
 <div class="table-responsive course-info {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander">
     {{ if not $inPanel }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-course-hugo-theme/issues/40

#### What's this PR do?
This PR corrects a bug with the `course_info.html` partial pulling the `inPanel` flag from the wrong location.

#### How should this be manually tested?
Spin up any course site using the instructions in the readme.  Verify that while on course pages that the course info drawer only includes one Topics section.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/110864312-ecd13580-828f-11eb-903b-e5f306a2fe44.png)
![image](https://user-images.githubusercontent.com/12089658/110864367-01adc900-8290-11eb-8714-d648e67d6f4f.png)

