### PR TITLE
use leftnav as left navigation menu key

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,10 +1,8 @@
-{{ $currentPage := . }}
-{{ $courseId := $currentPage.Params.course_id }}
-{{ $menu := index .Site.Menus $courseId }}
+{{ $menu := index .Site.Menus "leftnav" }}
 <nav id="course-nav" class="course-nav">
   <ul class="w-100 m-auto list-unstyled">
     {{ range $menu }}
-      {{ partial "nav_item.html" (dict "menuItem" . "currentPage" $currentPage "courseId" $courseId) }}
+      {{ partial "nav_item.html" (dict "menuItem" .) }}
     {{ end }}
   </ul>
 </nav>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/224

#### What's this PR do?
This PR changes the left navigation menu to be keyed off of `leftnav` rather than the course ID. Previously, when the output of `ocw-to-hugo` was used by `hugo-course-publisher`, all courses were built as a single Hugo site. This required us to key the left navigation for each course on its course id to keep the entries unique. Since courses all run in an isolated Hugo build now, we can simply key this on `leftnav`. This will make it more straightforward to construct a menu for any given course in `ocw-studio` because it will be stored in and referenced from a single key that describes what it is and where it goes; `leftnav`.

#### How should this be manually tested?
 - Read the readme and make sure you are familiar with spinning up course sites using Docker
 - Clone `ocw-to-hugo` locally and check out the `cg/leftnav` branch
 - Spin up a site for a course with a nested menu like `18-01sc-single-variable-calculus-fall-2010` using docker and ensure that the left nav renders properly and all the links work

#### Any background context you want to provide?
Check the related issue for other PR's related to this one. They'll need to be merged at the same time as this PR.
