### PR TITLE
td colspan shortcode

### DIFF
--- a/assets/scss/tables.scss
+++ b/assets/scss/tables.scss
@@ -4,16 +4,9 @@
     vertical-align: middle !important;
   }
 
-  .fullwidth-cell {
-    position: relative;
-    display: inline;
-  }
-
-  .fullwidth-cell-inner {
-    position: absolute;
-    width: calc(
-      (#{$max-content-width} - #{$desktop-nav-max-width}) * 0.6666667
-    );
-    margin: auto;
+  tr {
+    td:empty {
+      display: none;
+    }
   }
 }

--- a/layouts/shortcodes/fullwidth-cell.html
+++ b/layouts/shortcodes/fullwidth-cell.html
@@ -1,3 +1,0 @@
-<div class="fullwidth-cell">
-  <div class="fullwidth-cell-inner">{{ .Inner | markdownify }}</div>&nbsp;
-</div>

--- a/layouts/shortcodes/td-colspan.html
+++ b/layouts/shortcodes/td-colspan.html
@@ -1,0 +1,3 @@
+<td class="fullwidth-cell" colspan="{{ .Get 0 }}">
+  {{ .Inner | markdownify }}
+</td>

--- a/layouts/shortcodes/td-colspan.html
+++ b/layouts/shortcodes/td-colspan.html
@@ -1,3 +1,3 @@
-<td class="fullwidth-cell" colspan="{{ .Get 0 }}">
+<td colspan="{{ .Get 0 }}">
   {{ .Inner | markdownify }}
 </td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/226

#### What's this PR do?
This PR helps solve some issues related to inline "header" rows used by OCW in tables.  The issue itself is described in detail in [this](https://github.com/mitodl/ocw-to-hugo/pull/227) `ocw-to-hugo` PR.  Please read that PR's description to familiarize yourself with the issue before looking at this one.

In this PR specifically, the `fullwidth-cell` shortcode is replaced by `td-colspan`, which accepts a single int argument.  It returns a `td` element with the `colspan` attribute set to the value passed in.  This places a `td` within another `td`, which is technically not allowed.  The result in the rendered HTML in all browsers I tested was two side by side `td` elements, one empty and one with the title in it along with the `colspan` attribute.  These empty `td` elements are then hidden in `ocw-course-hugo-theme`'s styles by matching on `td:empty`.  Since intentional empty cells have an `&nbsp;` character entity inserted in them, they are not hidden.

#### How should this be manually tested?
 - Read the readme if you are unfamiliar with setting up a local course site using Docker
 - Make sure you have `ocw-to-hugo` cloned locally with the `cg/td-colspan` branch checked out and Docker is configured to use it
 - Spin up a course with title rows, a good example is `7-341-designer-immunity-lessons-in-engineering-the-immune-system-spring-2014`
 - Ensure that the titles properly render, spanning the whole table's width
 - Check the above on every browser you have access to

#### Any background context you want to provide?
There is an `ocw-to-hugo` PR that is responsible for generating the new `td-colspan` shortcodes [here](https://github.com/mitodl/ocw-to-hugo/pull/227).  Note that some tables still do not look right on mobile simply because they are too wide and there is too much information to be displayed on a phone.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/111411769-87c37880-86b1-11eb-9178-5dc20ae165ed.png)
![image](https://user-images.githubusercontent.com/12089658/111411827-a6297400-86b1-11eb-870d-2e9e5f64d62a.png)

