### PR TITLE
Larger font-size for description

### DIFF
--- a/assets/scss/course-info.scss
+++ b/assets/scss/course-info.scss
@@ -125,6 +125,10 @@
 }
 
 .course-description {
+  .description {
+    font-size: 1rem;
+  }
+
   &.collapsed {
     .description {
       max-height: 6rem;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #41 

#### What's this PR do?
Sets the font size for the description to the same font size as the main content of a section.

#### How should this be manually tested?
Run `docker-compose up` in the `docker/` directory and view the course description

#### Screenshots (if appropriate)
![Screenshot from 2021-03-17 13-00-18](https://user-images.githubusercontent.com/863262/111507467-102d3200-8721-11eb-847f-decf40642aa3.png)

