### PR TITLE
responsive tables

### DIFF
--- a/assets/js/responsive_tables.js
+++ b/assets/js/responsive_tables.js
@@ -1,0 +1,20 @@
+// set data-title attribute on table cells
+function responsiveTables() {
+  const tables = document.getElementById("main-content-wrapper").getElementsByTagName("table")
+  for (table of tables) {
+    const headings = table.getElementsByTagName("th")
+    const tbody = table.getElementsByTagName("tbody")
+    if (tbody.length > 0){
+      const rows = tbody[0].getElementsByTagName("tr")
+      for (row of rows) {
+        const cells = row.getElementsByTagName("td")
+        for (i = 0; i < cells.length; i++) {
+          if (headings.length >= i + 1) {
+            cells[i].setAttribute("data-title", headings[i].innerText.trim().concat(": "))
+          }
+        }
+      }
+    }
+  }
+}
+responsiveTables()

--- a/assets/js/responsive_tables.js
+++ b/assets/js/responsive_tables.js
@@ -1,17 +1,20 @@
 // set data-title attribute on table cells
 function responsiveTables() {
-  const tables = document.getElementById("main-content-wrapper").getElementsByTagName("table")
-  for (table of tables) {
+  const tables = document
+    .getElementById("main-content-wrapper")
+    .getElementsByTagName("table")
+  for (const table of tables) {
     const headings = table.getElementsByTagName("th")
-    const tbody = table.getElementsByTagName("tbody")
-    if (tbody.length > 0){
-      const rows = tbody[0].getElementsByTagName("tr")
-      for (row of rows) {
-        const cells = row.getElementsByTagName("td")
-        for (i = 0; i < cells.length; i++) {
-          if (headings.length >= i + 1) {
-            cells[i].setAttribute("data-title", headings[i].innerText.trim().concat(": "))
-          }
+    const tbody = table.getElementsByTagName("tbody")[0]
+    const rows = tbody.getElementsByTagName("tr")
+    for (const row of rows) {
+      const cells = row.getElementsByTagName("td")
+      for (i = 0; i < cells.length; i++) {
+        if (headings.length >= i + 1) {
+          cells[i].setAttribute(
+            "data-title",
+            headings[i].innerText.trim().concat(": ")
+          )
         }
       }
     }

--- a/assets/scss/tables.scss
+++ b/assets/scss/tables.scss
@@ -1,4 +1,4 @@
-.table {
+#main-content-wrapper .table {
   thead th,
   td {
     vertical-align: middle !important;
@@ -7,6 +7,44 @@
   tr {
     td:empty {
       display: none;
+    }
+  }
+
+  /* 
+    responsive table css based on:
+     https://css-tricks.com/responsive-data-tables/
+     https://elvery.net/demo/responsive-tables/#no-more-tables
+  */
+  @media 
+  only screen and (max-width: 760px),
+  (min-device-width: 768px) and (max-device-width: 1024px)  {
+
+    // Force table to not be like tables anymore
+    table, thead, tbody, th, td, tr { 
+      display: block; 
+    }
+    
+    // Hide table headers (but not display: none;, for accessibility)
+    thead tr { 
+      position: absolute;
+      top: -9999px;
+      left: -9999px;
+    }
+    
+    tr { border: 1px solid #ccc; }
+    
+    td { 
+      border: none;
+      border-bottom: 1px solid #eee; 
+    }
+    
+    td:before { 
+      /* 
+        The data-title attribute is written in using the table's headings
+        See responsive_tables.js for more info
+      */
+      content: attr(data-title);
+      font-weight: bold;
     }
   }
 }

--- a/assets/scss/tables.scss
+++ b/assets/scss/tables.scss
@@ -15,30 +15,35 @@
      https://css-tricks.com/responsive-data-tables/
      https://elvery.net/demo/responsive-tables/#no-more-tables
   */
-  @media 
-  only screen and (max-width: 760px),
-  (min-device-width: 768px) and (max-device-width: 1024px)  {
-
+  @media only screen and (max-width: 760px),
+    (min-device-width: 768px) and (max-device-width: 1024px) {
     // Force table to not be like tables anymore
-    table, thead, tbody, th, td, tr { 
-      display: block; 
+    table,
+    thead,
+    tbody,
+    th,
+    td,
+    tr {
+      display: block;
     }
-    
+
     // Hide table headers (but not display: none;, for accessibility)
-    thead tr { 
+    thead tr {
       position: absolute;
       top: -9999px;
       left: -9999px;
     }
-    
-    tr { border: 1px solid #ccc; }
-    
-    td { 
-      border: none;
-      border-bottom: 1px solid #eee; 
+
+    tr {
+      border: 1px solid #ccc;
     }
-    
-    td:before { 
+
+    td {
+      border: none;
+      border-bottom: 1px solid #eee;
+    }
+
+    td:before {
       /* 
         The data-title attribute is written in using the table's headings
         See responsive_tables.js for more info

--- a/layouts/course/baseof.html
+++ b/layouts/course/baseof.html
@@ -75,6 +75,7 @@
 
   </script>
   {{ partialCached "navigation_js.html" . }}
+  {{ partialCached "responsive_tables_js.html" . }}
   {{- $course := .Site.Data.webpack.course -}}
   {{- $mathjax := .Site.Data.webpack.mathjax -}}
 

--- a/layouts/partials/responsive_tables_js.html
+++ b/layouts/partials/responsive_tables_js.html
@@ -1,0 +1,5 @@
+{{ $navjs := resources.Get "js/responsive_tables.js" }}
+{{ $minified := $navjs | resources.Minify }}
+<script>
+{{ $minified.Content | safeJS }}
+</script>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/236

#### What's this PR do?
Some tables in OCW contain a lot of information and are too wide / contain too much information to be displayed properly at mobile resolutions.  This PR adds some CSS that transforms table elements into block level elements resembling "cards" when the resolution gets low enough.  A small native Javascript file was also added that looks through the tables under `#main-content-wrapper`, gets the headings and applies those in order as a `data-title` attribute to the cells.  The CSS applies those `data-title` attributes as `content` in the `:before` rule on the cell.

#### How should this be manually tested?
 - Set up this repo to run course sites locally using Docker as detailed in the readme
 - Spin up a course site for a course with a table, like `16-20-structural-mechanics-fall-2002`
 - Verify that at mobile resolutions, the table rows collapse into cards and display properly
 - Test the above in multiple browsers, any you have access to

#### Any background context you want to provide?
At the time of writing, there is no specific design for these cards so no styling is applied aside from what is necessary to display the table info as cards.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/112387816-9c62ca80-8cc8-11eb-8d7b-06d53dcf9fd2.png)
![image](https://user-images.githubusercontent.com/12089658/112387862-af759a80-8cc8-11eb-98e1-9fd6f4270998.png)

