### PR TITLE
Add back course_info_links.js

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -15,6 +15,7 @@ import "nanogallery2/src/jquery.nanogallery2.core.js"
 import { initPdfViewers } from "./js/pdf_viewer"
 import { initSentry } from "./js/sentry"
 import { initDesktopCourseInfoToggle } from "./js/course_info_toggle"
+import { rewriteCourseInfoLinks } from "./js/course_info_links"
 import { initCourseInfoExpander } from "./js/course_expander"
 
 window.jQuery = $
@@ -35,4 +36,5 @@ $(document).ready(() => {
   initSentry()
   initDesktopCourseInfoToggle()
   initCourseInfoExpander()
+  rewriteCourseInfoLinks()
 })

--- a/assets/js/course_info_links.js
+++ b/assets/js/course_info_links.js
@@ -1,0 +1,30 @@
+import { serializeSearchParams } from "@mitodl/course-search-utils/dist/url_utils"
+import { SEARCH_URL } from "./lib/constants"
+
+const INFO_LINK_MANIFEST = [
+  // see https://github.com/mitodl/hugo-course-publisher/pull/281#issuecomment-719547924
+  [".course-info-topic", "topics", null],
+  [".course-info-level", "level", null],
+  [".course-info-department", "department_name", null],
+  [".course-info-instructor", "q", "Prof."]
+]
+
+export const rewriteCourseInfoLinks = () => {
+  INFO_LINK_MANIFEST.forEach(([className, searchParam, replaceText]) => {
+    document.querySelectorAll(className).forEach(el => {
+      const value = el.textContent.replace(replaceText, "").trim()
+      const url = `${SEARCH_URL}?${serializeSearchParams(
+        searchParam === "q" ?
+          {
+            text: `"${value}"`
+          } :
+          {
+            activeFacets: {
+              [searchParam]: value
+            }
+          }
+      )}`
+      el.setAttribute("href", url)
+    })
+  })
+}

--- a/assets/js/lib/constants.js
+++ b/assets/js/lib/constants.js
@@ -1,2 +1,4 @@
 export const HIDE_COURSE_INFO_TEXT = "HIDE COURSE INFO"
 export const SHOW_COURSE_INFO_TEXT = "SHOW COURSE INFO"
+
+export const SEARCH_URL = "/search/"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
+set -e -o pipefail
+export PATH=$PATH:/usr/local/go/bin
 
 echo "Starting services..."
-set -e -o pipefail
 cd /theme
+yarn install
 npm start &
-export PATH=$PATH:/usr/local/go/bin
+
 # If the path to ocw-to-hugo is not set, use local content
 # Otherwise, download course content and use that instead
 if [[ -z "${OCW_TO_HUGO_PATH}" ]]; then
-  cd /theme/docker/hugo && /usr/local/bin/hugo server --bind 0.0.0.0
+  cd /theme
+  npm start &
+  cd /theme/docker/hugo
+  /usr/local/bin/hugo server --bind 0.0.0.0
 else
-  cd /ocw-to-hugo && yarn install && cd /theme && yarn install
-  rm -rf /ocw-data/* && mkdir /ocw-data/input && mkdir /ocw-data/output
+  cd /ocw-to-hugo
+  yarn install
+  rm -rf /ocw-data/*
+  mkdir /ocw-data/input /ocw-data/output
   echo "{\"courses\":[\"${OCW_TEST_COURSE}\"]}" | tee /ocw-data/courses.json
-  cd /ocw-to-hugo && node . -i ${OCW_TO_HUGO_INPUT:-/ocw-data/input} \
+  cd /ocw-to-hugo
+  node . -i ${OCW_TO_HUGO_INPUT:-/ocw-data/input} \
     -o /ocw-data/output -c /ocw-data/courses.json --download ${OCW_TO_HUGO_DOWNLOAD:-true}
   rm -rf /ocw-to-hugo-output/*
   cp /theme/docker/hugo/go.mod /ocw-to-hugo-output/go.mod
   cp /theme/docker/hugo/config.toml /ocw-to-hugo-output/config.toml
   cp -R /ocw-data/output/${OCW_TEST_COURSE}/* /ocw-to-hugo-output/
-  cd /ocw-to-hugo-output && /usr/local/bin/hugo server --bind 0.0.0.0
+
+  cd /ocw-to-hugo-output
+  /usr/local/bin/hugo server --bind 0.0.0.0
 fi

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
+    "@mitodl/course-search-utils": "^1.1.2",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@mitodl/course-search-utils@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.1.2.tgz#14fdc1b01dde1572903df925622f5cf52a0c7ac6"
+  integrity sha512-KWBODgXnZUauv9luYzBBr/M35A8x3m+umoQbD9EWKAyM9ZQdOdL+RbRJYVedNV7e/RgxjS1S/TPucLlbCnFkqg==
+  dependencies:
+    query-string "^6.13.1"
+    ramda "^0.27.1"
+
 "@popperjs/core@^2.4.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
@@ -5171,6 +5179,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -10145,6 +10158,16 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.13.1:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
+  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10172,7 +10195,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-ramda@^0.27.0:
+ramda@^0.27.0, ramda@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
@@ -11311,6 +11334,11 @@ spinkit@^2.0.1:
   resolved "https://registry.yarnpkg.com/spinkit/-/spinkit-2.0.1.tgz#aefcd0acfdf15a90aa8e1f069d7e618515891f74"
   integrity sha512-oYBGY0GV1H1dX+ZdKnB6JVsYC1w/Xl20H111eb+WSS8nUYmlHgGb4y5buFSkzzceEeYYh5kMhXoAmoTpiQauiA==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11436,6 +11464,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #64 

#### What's this PR do?
Adds back a javascript file from hugo-course-publisher which implemented links in the course info. I also made minor changes to `start.sh` so that webpack-dev-server or other prerequisites are installed before starting the server.

#### How should this be manually tested?
Start up docker for any course page. Click the "course info" expander link then click one of the underlined links inside such as a topic or instructor. On main you should not see anything happen, but on this PR clicking the link should direct you to `/search/?q=...`. This will look like a broken link on your local instance but it should work fine on ocwnext.odl.mit.edu