### PR TITLE
Fix course info links

### DIFF
--- a/layouts/partials/course_info.html
+++ b/layouts/partials/course_info.html
@@ -18,7 +18,7 @@
       <tr>
         <td class="pl-0">{{ if eq (len $courseData.instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
         <td>
-          {{ partial "partial_collapse_list.html" (dict "list" $courseData.instructors "id" "instructors" "klass" "course-info-instructor") }}
+          {{ partial "partial_collapse_list.html" (dict "list" $courseData.instructors "id" "instructors" "key" "instructor" "klass" "course-info-instructor") }}
         </td>
       </tr>
       <tr>
@@ -28,7 +28,7 @@
       <tr>
         <td class="pl-0">Departments:</td>
         <td>
-          {{ partial "partial_collapse_list.html" (dict "list" $courseData.departments "id" "departments" "klass" "course-info-department") }}
+          {{ partial "partial_collapse_list.html" (dict "list" $courseData.departments "id" "departments" "key" "department" "klass" "course-info-department") }}
         </td>
       </tr>
       {{ if not $inPanel }}
@@ -48,11 +48,12 @@
       <tr>
         <td class="pl-0 pb-3">Level:</td>
         <td>
-          <a href="#" class="course-info-level">
-            {{ $courseData.level }}
+          <a href="{{ $courseData.level.url }}" class="course-info-level">
+            {{ $courseData.level.level }}
           </a>
         </td>
       </tr>
     </table>
   </div>
 </div>
+

--- a/layouts/partials/partial_collapse_list.html
+++ b/layouts/partials/partial_collapse_list.html
@@ -1,3 +1,4 @@
+{{ $params := . }}
 {{ $className := .klass | default "coming-soon" }}
 {{ $useLinks := .useLinks | default true }}
 {{ if gt (len .list) 4 }}
@@ -13,14 +14,20 @@
   <div class="partial-collapse collapse" id="partial-collapse-container_{{ .id }}">
     <ul class="list-unstyled m-0">
       {{ range $item := .list }}
+      {{ $text := "" }}
+      {{ if isset $params "key" }}
+        {{ $text = index $item $params.key }}
+      {{ else }}
+        {{ $text = $item }}
+      {{ end }}
       <li>
         {{ if $useLinks }}
-        <a href="#" class="partial-collapse-link {{ $className }}">
-          {{ $item }}
+        <a href="{{ index $item "url" }}" class="partial-collapse-link {{ $className }}">
+          {{ $text }}
         </a>
         {{ else }}
-        {{ $item }}
-        {{end }}
+        {{ $text }}
+        {{ end }}
       </li>
       {{ end }}
     </ul>
@@ -30,14 +37,20 @@
 {{ else }}
 <ul class="list-unstyled m-0">
   {{ range $item := .list }}
+  {{ $text := "" }}
+  {{ if isset $params "key" }}
+    {{ $text = index $item $params.key }}
+  {{ else }}
+    {{ $text = $item }}
+  {{ end }}
   <li>
     {{ if $useLinks }}
-    <a href="#" class="{{ $className }}">
-      {{ $item }}
+    <a href="{{ index $item "url" }}" class="{{ $className }}">
+      {{ $text }}
     </a>
     {{ else }}
-    {{ $item }}
-    {{end }}
+    {{ $text }}
+    {{ end }}
   </li>
   {{ end }}
 </ul>

--- a/layouts/partials/topic.html
+++ b/layouts/partials/topic.html
@@ -12,7 +12,7 @@
   </a>
   {{ end }}
   <span class="topic-text-wrapper">
-    <a class="text-black course-info-topic" href="#">
+    <a class="text-black course-info-topic" href="{{ .topic.url }}">
     {{ title .topic.topic }}
     </a>
   </span>
@@ -32,7 +32,7 @@
     </a>
     {{ end }}
     <span class="topic-text-wrapper">
-      <a class="text-black course-info-topic" href="#">
+      <a class="text-black course-info-topic" href="{{ $subtopic.url }}">
       {{ title $subtopic.subtopic }}
       </a>
     </span>
@@ -40,8 +40,8 @@
   {{ range $specialities }}
   <div class="pt-1 pb-1 pl-5 collapse{{if eq $index 0 }} show{{ end }}" id="speciality-container_{{ $index }}_{{ $subtopicIndex }}">
     <span class="topic-text-wrapper">
-      <a class="text-black course-info-topic" href="#">
-      {{ . }}
+      <a class="text-black course-info-topic" href="{{ .url }}">
+      {{ .speciality }}
       </a>
     </span>
   </div>

--- a/layouts/partials/topics_oneline.html
+++ b/layouts/partials/topics_oneline.html
@@ -5,26 +5,26 @@
   {{ if gt (len $topic.subtopics) 0 }}
     {{ range $subtopic := $topic.subtopics }}
       {{ if gt (len $subtopic.specialities) 0 }}
-        {{ range $specialty := $subtopic.specialities }}
+        {{ range $speciality := $subtopic.specialities }}
           <li>
-            <a class="text-black course-info-topic">{{ $topic.topic }}</a>
+            <a href="{{ $topic.url }}" class="text-black course-info-topic">{{ $topic.topic }}</a>
             >
-            <a class="text-black course-info-topic">{{ $subtopic.subtopic }}</a>
+            <a href="{{ $subtopic.url }}" class="text-black course-info-topic">{{ $subtopic.subtopic }}</a>
             >
-            <a class="text-black course-info-topic">{{ $specialty }}</a>
+            <a href="{{ $speciality.url }}" class="text-black course-info-topic">{{ $speciality.speciality }}</a>
           </li>
         {{ end }}
       {{ else }}
         <li>
-          <a class="text-black course-info-topic">{{ $topic.topic }}</a>
+          <a href="{{ $topic.url }}" class="text-black course-info-topic">{{ $topic.topic }}</a>
           >
-          <a class="text-black course-info-topic">{{ $subtopic.subtopic }}</a>
+          <a href="{{ $subtopic.url }}" class="text-black course-info-topic">{{ $subtopic.subtopic }}</a>
         </li>
       {{ end }}
     {{ end }}
   {{ else }}
     <li>
-      <a class="text-black course-info-topic">{{ $topic.topic }}</a>
+      <a href="{{ $topic.url }}" class="text-black course-info-topic">{{ $topic.topic }}</a>
     </li>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-to-hugo/issues/243. There is a corresponding PR in ocw-to-hugo: https://github.com/mitodl/ocw-to-hugo/pull/244

#### What's this PR do?
Adds URLs for department, topic, instructor, and level links in the course info section.

#### How should this be manually tested?
Check out `gs/course-info-links` on `ocw-to-hugo` and make sure it's referenced in the docker configuration. Many courses will have all the right info but `16-20-structural-mechanics-fall-2002` is the one I tested with. Start up docker and view the course info page. Hover over each of these kinds of links and verify:
 - topics: Each link should have a URL like `/search/?t=Engineering` for example. You should see these links on the topic, subtopic, and speciality links.
 - level: You should see something like `/search/?l=Undergraduate`
 - department: You should see `/search/?d=Aeronautics and Astronautics` or similar
 - instructors: The text should have `Prof. ` prefixed to each name, and the URL should look like `/search/?q="Paul Lagace"` or similar, without the `Prof.`
