### PR TITLE
course_feature_tags template update

### DIFF
--- a/assets/scss/course-home.scss
+++ b/assets/scss/course-home.scss
@@ -45,6 +45,10 @@
       padding: 0;
     }
 
+    a {
+      text-decoration: none;
+    }
+
     .course-feature-icon {
       color: #ff8924;
     }

--- a/layouts/partials/course_feature.html
+++ b/layouts/partials/course_feature.html
@@ -1,44 +1,30 @@
-<div class="d-inline-flex pr-5 pb-2 font-weight-bold align-items-center">
-  <i class="course-feature-icon material-icons h2 pr-2 mb-0">
-    {{ if eq .feature "AV faculty introductions" }}
-    groups
-    {{ else if eq .feature "AV lectures" }}
-    record_voice_over
-    {{ else if eq .feature "AV recitations" }}
-    hearing
-    {{ else if eq .feature "AV selected lectures" }}
-    record_voice_over
-    {{ else if eq .feature "AV special element audio" }}
-    equalizer
-    {{ else if eq .feature "AV special element video" }}
-    theaters
-    {{ else if eq .feature "Assignments" }}
-    assignment_turned_in
-    {{ else if eq .feature "Exams" }}
-    grading
-    {{ else if eq .feature "Image Gallery" }}
-    collections
-    {{ else if eq .feature "Instructor Insights" }}
-    record_voice_over
-    {{ else if eq .feature "Interactive assessments" }}
-    assignment_turned_in
-    {{ else if eq .feature "Interactive simulations" }}
-    laptop_windows
-    {{ else if eq .feature "Lecture notes" }}
-    notes
-    {{ else if eq .feature "Online textbooks" }}
-    menu_book
-    {{ else if eq .feature "Projects" }}
-    group_work
-    {{ else if eq .feature "Resource Index" }}
-    list
-    {{ else if eq .feature "Simulations" }}
-    laptop_windows
-    {{ else if eq .feature "This Course at MIT" }}
-    school
-    {{ end }}
-  </i>
-  <span>
-    {{ .feature }}{{ if isset . "subfeature" }} - {{ .subfeature }}{{ end }}
-  </span>
-</div>
+<a href="{{- .url -}}">
+  <div class="d-inline-flex pr-5 pb-2 font-weight-bold align-items-center">
+    <i class="course-feature-icon material-icons h2 pr-2 mb-0">
+      {{ if eq .feature "Course Introduction" }}
+      groups
+      {{ else if eq .feature "Lecture Audio" }}
+      equalizer
+      {{ else if eq .feature "Lecture Video" }}
+      theaters
+      {{ else if eq .feature "Problem Sets" }}
+      assignment_turned_in
+      {{ else if eq .feature "Exams" }}
+      grading
+      {{ else if eq .feature "Image Gallery" }}
+      collections
+      {{ else if eq .feature "Lecture Notes" }}
+      notes
+      {{ else if eq .feature "Online Textbook" }}
+      menu_book
+      {{ else if eq .feature "Projects" }}
+      group_work
+      {{ else if eq .feature "Simulations" }}
+      laptop_windows
+      {{ end }}
+    </i>
+    <span>
+      {{ .feature }}
+    </span>
+  </div>
+</a>

--- a/layouts/partials/course_feature.html
+++ b/layouts/partials/course_feature.html
@@ -1,30 +1,34 @@
 <a href="{{- .url -}}">
   <div class="d-inline-flex pr-5 pb-2 font-weight-bold align-items-center">
     <i class="course-feature-icon material-icons h2 pr-2 mb-0">
-      {{ if eq .feature "Course Introduction" }}
+      {{- if eq .feature "Course Introduction" -}}
       groups
-      {{ else if eq .feature "Lecture Audio" }}
+      {{- else if in .feature "Audio" -}}
       equalizer
-      {{ else if eq .feature "Lecture Video" }}
+      {{- else if in .feature "Video" -}}
       theaters
-      {{ else if eq .feature "Problem Sets" }}
-      assignment_turned_in
-      {{ else if eq .feature "Exams" }}
+      {{- else if or (in .feature "Problem Sets") (in .feature "Assignment") -}}
+        {{- if or (in .feature "with Examples") (in .feature "with Solutions") -}}
+        assignment_turned_in
+        {{- else -}}
+        assignment
+        {{- end -}}
+      {{- else if in .feature "Exams" -}}
       grading
-      {{ else if eq .feature "Image Gallery" }}
+      {{- else if eq .feature "Image Gallery" -}}
       collections
-      {{ else if eq .feature "Lecture Notes" }}
+      {{- else if eq .feature "Lecture Notes" -}}
       notes
-      {{ else if eq .feature "Online Textbook" }}
+      {{- else if eq .feature "Online Textbook" -}}
       menu_book
-      {{ else if eq .feature "Projects" }}
+      {{- else if in .feature "Projects" -}}
       group_work
-      {{ else if eq .feature "Simulations" }}
+      {{- else if in .feature "Simulations" -}}
       laptop_windows
-      {{ end }}
+      {{- end -}}
     </i>
     <span>
-      {{ .feature }}
+      {{- .feature -}}
     </span>
   </div>
 </a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
https://github.com/mitodl/ocw-to-hugo/issues/247

#### What's this PR do?
Recently we made a change to `ocw-data-parser` that consolidates `course_features` down into a smaller list of `course_feature_tags`. This PR sets up `ocw-course-hugo-theme`  to work with the changes made to support that in [this](https://github.com/mitodl/ocw-to-hugo/pull/249) `ocw-to-hugo` PR.

#### How should this be manually tested?
 - Read the readme and familiarize yourself with running a course site locally in Docker if you have not done this already
 - Clone `ocw-to-hugo` locally on the `cg/course-feature-tags` branch and set up this project to use it in the `.env` file
 - Spin up a course site for any course
 - Ensure that the generated course features match the data in the `course_feature_tags` property of that course's parsed JSON (the output from `ocw-data-parser` that `ocw-to-hugo` consumes)
 - Ensure that each course feature has a link that you can click that navigates to a course section

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/113458234-b34ba000-93df-11eb-9227-3ea47ae54cd4.png)
![image](https://user-images.githubusercontent.com/12089658/113458275-d1b19b80-93df-11eb-973f-058b7f549269.png)

