### PR TITLE
prepend baseurl to course feature urls

### DIFF
--- a/layouts/partials/course_feature.html
+++ b/layouts/partials/course_feature.html
@@ -1,4 +1,4 @@
-<a href="{{- .url -}}">
+<a href="{{- strings.TrimSuffix "/" site.BaseURL -}}{{- .url -}}">
   <div class="d-inline-flex pr-5 pb-2 font-weight-bold align-items-center">
     <i class="course-feature-icon material-icons h2 pr-2 mb-0">
       {{- if eq .feature "Course Introduction" -}}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-course-hugo-theme/issues/84

#### What's this PR do?
Course feature URLs are currently not being generated with the `baseUrl` in front of them, resulting in broken links in the full site build.  This PR prepends these urls with the configured `baseUrl`.

#### How should this be manually tested?
 - Read the readme if you have never spun up a course site locally before to learn how to
 - Make a temporary edit to the docker `start.sh` file, adding the `--baseUrl` argument to the `hugo server` line like so:
 ```
cd /ocw-to-hugo-output && /usr/local/bin/hugo server --bind 0.0.0.0 --baseUrl http://localhost:1313/courses/3-080-economic-environmental-issues-in-materials-selection-fall-2005
 ```
 - Start the site and browse to http://localhost:1313/courses/3-080-economic-environmental-issues-in-materials-selection-fall-2005/
 - Click the course feature links and ensure that they go to the proper sections
