### PR TITLE
force mobile style if table width exceeds main content area

### DIFF
--- a/assets/js/responsive_tables.js
+++ b/assets/js/responsive_tables.js
@@ -1,12 +1,12 @@
-// set data-title attribute on table cells
-function responsiveTables() {
+function initResponsiveTables() {
   const tables = document
-    .getElementById("main-content-wrapper")
+    .getElementById("main-content")
     .getElementsByTagName("table")
   for (const table of tables) {
     const headings = table.getElementsByTagName("th")
     const tbody = table.getElementsByTagName("tbody")[0]
     const rows = tbody.getElementsByTagName("tr")
+    // set data-title attribute on table cells
     for (const row of rows) {
       const cells = row.getElementsByTagName("td")
       for (let i = 0; i < cells.length; i++) {
@@ -18,6 +18,12 @@ function responsiveTables() {
         }
       }
     }
+    // force mobile style if table width exceeds main content area
+    const tableWidth = table.clientWidth
+    const mainContentWidth = document.getElementById("main-content").clientWidth
+    if (tableWidth > mainContentWidth) {
+      table.classList.add("mobile-table")
+    }
   }
 }
-responsiveTables()
+initResponsiveTables()

--- a/assets/scss/tables.scss
+++ b/assets/scss/tables.scss
@@ -1,4 +1,46 @@
-#main-content-wrapper .table {
+/* 
+  responsive table css based on:
+  https://css-tricks.com/responsive-data-tables/
+  https://elvery.net/demo/responsive-tables/#no-more-tables
+*/
+@mixin mobile-table {
+  // Force table to not be like tables anymore
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
+  }
+
+  // Hide table headers (but not display: none;, for accessibility)
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  tr {
+    border: 1px solid #ccc;
+  }
+
+  td {
+    border: none;
+    border-bottom: 1px solid #eee;
+  }
+
+  td:before {
+    /* 
+      The data-title attribute is written in using the table's headings
+      See responsive_tables.js for more info
+    */
+    content: attr(data-title);
+    font-weight: bold;
+  }
+}
+
+#main-content .table {
   thead th,
   td {
     vertical-align: middle !important;
@@ -10,46 +52,12 @@
     }
   }
 
-  /* 
-    responsive table css based on:
-     https://css-tricks.com/responsive-data-tables/
-     https://elvery.net/demo/responsive-tables/#no-more-tables
-  */
   @media only screen and (max-width: 760px),
     (min-device-width: 768px) and (max-device-width: 1024px) {
-    // Force table to not be like tables anymore
-    table,
-    thead,
-    tbody,
-    th,
-    td,
-    tr {
-      display: block;
-    }
-
-    // Hide table headers (but not display: none;, for accessibility)
-    thead tr {
-      position: absolute;
-      top: -9999px;
-      left: -9999px;
-    }
-
-    tr {
-      border: 1px solid #ccc;
-    }
-
-    td {
-      border: none;
-      border-bottom: 1px solid #eee;
-    }
-
-    td:before {
-      /* 
-        The data-title attribute is written in using the table's headings
-        See responsive_tables.js for more info
-      */
-      content: attr(data-title);
-      font-weight: bold;
-    }
+    @include mobile-table;
   }
+}
+
+.mobile-table {
+  @include mobile-table;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-course-hugo-theme/issues/75
Fixes https://github.com/mitodl/ocw-course-hugo-theme/issues/86

#### What's this PR do?
As the issue above mentions, some OCW pages have tables with long text that does not wrap well, causing the table to overflow outside the bounds of the main content area.  I've been thinking about this over the past couple of days and thought about a couple of different approaches.  I ended up going with a simple native JS approach that applies the mobile style to the table if its `clientWidth` property is greater than the `main-content` div's `clientWidth` property.  This also fixes an issue with the mobile table styling applying to the course info drawer, as it limits the scope to tables inside the `main-content` div instead of `main-content-wrapper`.

#### Any background context you want to provide?
These are the potential solutions I thought about / tried:

 - Try and intercept particularly long lines in cells during `ocw-to-hugo` conversion and use line break shortcodes to break up the text
   - Pros:
     - Solves the problem in the source content, doesn't require any JS / CSS changes to the course theme.
   - Cons:
     - This is potentially unreliable as Markdown tables are meant to be simple with each row representing a table row.  We would have to set a "threshold" where we would inject line break shortcodes (`{{< br >}}`) in the middle of long text.
     - May not work if the line break shortcodes are used in the middle of other markdown elements like links
     - Will look weird if the user adjusts the zoom level of their browser
 - Use an element query polyfill like [css-element-queries](https://github.com/marcj/css-element-queries) or [eqcss](https://github.com/eqcss/eqcss) to apply the mobile styling using `min-width` element queries
   - Pros:
     - Both libraries above have good performance and cross browser support and are implemented with the hope that element queries will eventually be part of the official CSS spec
     - Element queries could be useful elsewhere in the project in the future
   - Cons:
     - Adds a third party dependency
     - Doesn't simply "just work" for this use case, as using a `min-width` rule on tables to apply the mobile styling when the width exceeds the main content area changes the table's width, resulting in the rule not applying anymore.  The layout thrashes between the desktop and mobile style infinitely.  We would need to come up with some kind of solution to only apply the rule if the mobile styling has not yet been applied.
 - Add simple native JS to `responsive_tables.js` to measure the table and main content area, applying the mobile table style if the table is bigger than the content area
   - Pros:
     - Very lightweight and fast, uses `clientWidth` which is supported and consistent across all browsers
     - Doesn't require any third party dependencies
     - Very small code change
   - Cons:
     - This doesn't handle resize events, it only applies mobile style to tables that exceed the width of the content area at page load.  The only situation this applies to is if you load a page maximized and then reduce the size to the point where the table doesn't fit in the main content area.

Another thing I tried was a hybrid of the 2nd and 3rd solutions.  The native JS code quickly reacts to tables that overflow the content area and resizes them before anything loads in the browser window.  The `css-element-queries` library includes a class called `ResizeSensor`.  It's a cross-browser polyfill for Chrome's `ResizeObserver`.  I experimented with implenting just this part of the library to watch for resizing of the main content area and then fire the native JS code to check and apply the mobile table style in the case of overflow.  It worked well, but some of the cons come along with it.  It would mean adding a 3rd party dependency, and while `ResizeSensor` is pretty performant, it does add a performance cost on pages with tables on them for what is effectively an edge case.

Ultimately, I decided the best approach given all of the above was just to use some basic native JS to check the widths on page load.

#### How should this be manually tested?
 - Read the readme to learn how to spin up a course site if you have not done so before
 - Spin up the course from the issue, `18-s096-topics-in-mathematics-with-applications-in-finance-fall-2013`
 - Visit the Case Studies page, which even at max content width should be transformed into the mobile view, compared to the live page which overflows: https://ocwnext.odl.mit.edu/courses/18-s096-topics-in-mathematics-with-applications-in-finance-fall-2013/sections/case-studies/

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/115789682-8281d980-a393-11eb-8e96-2c1bfb3d4471.png)
![image](https://user-images.githubusercontent.com/12089658/115789699-87df2400-a393-11eb-85ff-b14b8ce6df33.png)
![image](https://user-images.githubusercontent.com/12089658/115789807-b9f08600-a393-11eb-9cda-50d55572f55f.png)

